### PR TITLE
Dependency::registered() should be declared as static

### DIFF
--- a/dependency.class.php
+++ b/dependency.class.php
@@ -26,7 +26,7 @@
             self::instance()->register[] = $func;
         }
 
-        public function registered()
+        public static function registered()
         {
             return self::instance()->register;
         }


### PR DESCRIPTION
In `rocket_pack.class.php` at [#L11](https://github.com/iaindooley/RocketPack/blob/master/rocket_pack.class.php#L11) `Dependency::registered()` is called statically.
